### PR TITLE
所持している設計図の一覧表示の実装

### DIFF
--- a/src/main/java/model/EquipmentItem.java
+++ b/src/main/java/model/EquipmentItem.java
@@ -1,42 +1,44 @@
 package model;
 
 public enum EquipmentItem {
-    LEATHER_HELMET(1, "皮のヘルメット", EquipmentPosition.HEAD, 2, 0, 0, 2, 0, "leather_helmet.png",new Status(5, 0, 1, 0),0),
-    COPPER_HELMET(2, "銅のヘルメット", EquipmentPosition.HEAD, 4, 0, 0, 4, 2, "copper_helmet.png",new Status(10, 0, 1, 0),0),
-    IRON_HELMET(3, "鉄のヘルメット", EquipmentPosition.HEAD, 4, 3, 0, 4, 1, "iron_helmet.png",new Status(20, 0, 0, 0),0),
-    DIAMOND_HELMET(4, "ダイヤのヘルメット", EquipmentPosition.HEAD, 4, 4, 2, 6, 1, "diamond_helmet.png",new Status(25, 0, 1, 0),0),
-    LEATHER_ARMOR(5, "皮のアーマー", EquipmentPosition.BODY, 4, 0, 0, 4, 0, "leather_armor.png",new Status(10, 0, 2, 0),0),
-    COPPER_ARMOR(6, "銅のアーマー", EquipmentPosition.BODY, 6, 0, 0, 6, 4, "copper_armor.png",new Status(15, 0, 1, 0),0),
-    IRON_ARMOR(7, "鉄のアーマー", EquipmentPosition.BODY, 6, 5, 0, 6, 2, "iron_armor.png",new Status(30, 0, 0, 0),0),
-    DIAMOND_ARMOR(8, "ダイヤのアーマー", EquipmentPosition.BODY, 6, 5, 3, 8, 2, "diamond_armor.png",new Status(40, 0, 1, 0),0),
-    WOOD_SWORD(9, "木の剣", EquipmentPosition.RIGHT_HAND, 4, 0, 0, 0, 0, "wood_sword.png",new Status(0, 3, 1, 0),0),
-    IRON_SWORD(10, "鉄の剣", EquipmentPosition.RIGHT_HAND, 2, 4, 0, 0, 1, "iron_sword.png",new Status(0, 10, 0, 0),0),
-    DIAMOND_SWORD(11, "ダイヤの剣", EquipmentPosition.RIGHT_HAND, 2, 2, 4, 0, 0, "diamond_sword.png",new Status(0, 20, 0, 1),0),
-    WOOD_SPEAR(12, "木の槍", EquipmentPosition.RIGHT_HAND, 3, 0, 0, 0, 0, "wood_spear.png",new Status(0, 3, 0, 1),0),
-    IRON_SPEAR(13, "鉄の槍", EquipmentPosition.RIGHT_HAND, 2, 4, 0, 0, 1, "iron_spear.png",new Status(0, 10, 0, 1),0),
-    DIAMOND_SPEAR(14, "ダイヤの槍", EquipmentPosition.RIGHT_HAND, 2, 2, 5, 0, 2, "diamond_spear.png",new Status(0, 20, 0, 2),0),
-    WOOD_ARROW(15, "木の弓", EquipmentPosition.RIGHT_HAND, 5, 0, 0, 2, 0, "wood_arrow.png",new Status(0,5,0,2),0),
-    IRON_ARROW(16, "鉄の弓", EquipmentPosition.RIGHT_HAND, 3, 4, 0, 2, 0, "iron_arrow.png",new Status(0,15,0,3),0),
-    DIAMOND_ARROW(17, "ダイヤの弓", EquipmentPosition.RIGHT_HAND, 0, 2, 6, 2, 2, "diamond_arrow.png",new Status(0,25,0,3),0),
-    WOOD_SHIELD(18, "木の盾", EquipmentPosition.LEFT_HAND, 4, 1, 0, 0, 0, "wood_shield.png",new Status(3,0,0,0),0),
-    IRON_SHIELD(19, "鉄の盾", EquipmentPosition.LEFT_HAND, 2, 4, 0, 0, 1, "iron_shield.png",new Status(10,0,0,0),0),
-    DIAMOND_SHIELD(20, "ダイヤの盾", EquipmentPosition.LEFT_HAND, 0, 2, 6, 0, 2, "diamond_shield.png",new Status(30,0,0,0),0),
-    WOOD_DAGGER(21, "木の短剣", EquipmentPosition.LEFT_HAND, 2, 0, 0, 0, 0, "wood_dagger.png",new Status(0, 2, 0, 0),0),
-    IRON_DAGGER(22, "鉄の短剣", EquipmentPosition.LEFT_HAND, 2, 3, 0, 0, 1, "iron_dagger.png",new Status(0, 8, 0, 0),0),
-    DIAMOND_DAGGER(23, "ダイヤの短剣", EquipmentPosition.LEFT_HAND, 1, 1, 3, 0, 3, "diamond_dagger.png",new Status(0, 15, 0, 0),0);
+    LEATHER_HELMET(1, "皮のヘルメット", EquipmentPosition.HEAD, 2, 0, 0, 2, 0, "leather_helmet.png", new Status(5, 0, 1, 0)),
+    COPPER_HELMET(2, "銅のヘルメット", EquipmentPosition.HEAD, 4, 0, 0, 4, 2, "copper_helmet.png", new Status(10, 0, 1, 0)),
+    IRON_HELMET(3, "鉄のヘルメット", EquipmentPosition.HEAD, 4, 3, 0, 4, 1, "iron_helmet.png", new Status(20, 0, 0, 0)),
+    DIAMOND_HELMET(4, "ダイヤのヘルメット", EquipmentPosition.HEAD, 4, 4, 2, 6, 1, "diamond_helmet.png", new Status(25, 0, 1, 0)),
+    LEATHER_ARMOR(5, "皮のアーマー", EquipmentPosition.BODY, 4, 0, 0, 4, 0, "leather_armor.png", new Status(10, 0, 2, 0)),
+    COPPER_ARMOR(6, "銅のアーマー", EquipmentPosition.BODY, 6, 0, 0, 6, 4, "copper_armor.png", new Status(15, 0, 1, 0)),
+    IRON_ARMOR(7, "鉄のアーマー", EquipmentPosition.BODY, 6, 5, 0, 6, 2, "iron_armor.png", new Status(30, 0, 0, 0)),
+    DIAMOND_ARMOR(8, "ダイヤのアーマー", EquipmentPosition.BODY, 6, 5, 3, 8, 2, "diamond_armor.png", new Status(40, 0, 1, 0)),
+    WOOD_SWORD(9, "木の剣", EquipmentPosition.RIGHT_HAND, 4, 0, 0, 0, 0, "wood_sword.png", new Status(0, 3, 1, 0)),
+    IRON_SWORD(10, "鉄の剣", EquipmentPosition.RIGHT_HAND, 2, 4, 0, 0, 1, "iron_sword.png", new Status(0, 10, 0, 0)),
+    DIAMOND_SWORD(11, "ダイヤの剣", EquipmentPosition.RIGHT_HAND, 2, 2, 4, 0, 0, "diamond_sword.png", new Status(0, 20, 0, 1)),
+    WOOD_SPEAR(12, "木の槍", EquipmentPosition.RIGHT_HAND, 3, 0, 0, 0, 0, "wood_spear.png", new Status(0, 3, 0, 1)),
+    IRON_SPEAR(13, "鉄の槍", EquipmentPosition.RIGHT_HAND, 2, 4, 0, 0, 1, "iron_spear.png", new Status(0, 10, 0, 1)),
+    DIAMOND_SPEAR(14, "ダイヤの槍", EquipmentPosition.RIGHT_HAND, 2, 2, 5, 0, 2, "diamond_spear.png", new Status(0, 20, 0, 2)),
+    WOOD_ARROW(15, "木の弓", EquipmentPosition.RIGHT_HAND, 5, 0, 0, 2, 0, "wood_arrow.png", new Status(0, 5, 0, 2)),
+    IRON_ARROW(16, "鉄の弓", EquipmentPosition.RIGHT_HAND, 3, 4, 0, 2, 0, "iron_arrow.png", new Status(0, 15, 0, 3)),
+    DIAMOND_ARROW(17, "ダイヤの弓", EquipmentPosition.RIGHT_HAND, 0, 2, 6, 2, 2, "diamond_arrow.png", new Status(0, 25, 0, 3)),
+    WOOD_SHIELD(18, "木の盾", EquipmentPosition.LEFT_HAND, 4, 1, 0, 0, 0, "wood_shield.png", new Status(3, 0, 0, 0)),
+    IRON_SHIELD(19, "鉄の盾", EquipmentPosition.LEFT_HAND, 2, 4, 0, 0, 1, "iron_shield.png", new Status(10, 0, 0, 0)),
+    DIAMOND_SHIELD(20, "ダイヤの盾", EquipmentPosition.LEFT_HAND, 0, 2, 6, 0, 2, "diamond_shield.png", new Status(30, 0, 0, 0)),
+    WOOD_DAGGER(21, "木の短剣", EquipmentPosition.LEFT_HAND, 2, 0, 0, 0, 0, "wood_dagger.png", new Status(0, 2, 0, 0)),
+    IRON_DAGGER(22, "鉄の短剣", EquipmentPosition.LEFT_HAND, 2, 3, 0, 0, 1, "iron_dagger.png", new Status(0, 8, 0, 0)),
+    DIAMOND_DAGGER(23, "ダイヤの短剣", EquipmentPosition.LEFT_HAND, 1, 1, 3, 0, 3, "diamond_dagger.png", new Status(0, 15, 0, 0));
 
+    public static final int LENGTH = EquipmentItem.values().length;
     public final int ID;
     public final String name;
     public final EquipmentPosition position;
     public final int req_wood, req_iron, req_diamond, req_leather, req_copper;
     public final String imgPath;
+    public final Status baseStatus;
 
 
     EquipmentItem(
             int id,
             String name,
             EquipmentPosition pos,
-            int wood, int iron, int diamond, int leather, int copper, String imgPath
+            int wood, int iron, int diamond, int leather, int copper, String imgPath, Status baseStatus
     ) {
         this.ID = id;
         this.name = name;
@@ -47,21 +49,16 @@ public enum EquipmentItem {
         this.req_leather = leather;
         this.req_copper = copper;
         this.imgPath = imgPath;
-        this.status = status;
+        this.baseStatus = baseStatus;
     }
 
     public String getAssetPath() {
         return "./assets/imgs/equips/" + this.imgPath;
     }
 
-    public Status getBaseStatus() {
-        // TODO: Equipmentに応じて値を変更する必要がある。
-        return new Status(20, 20, 20, 20);
-    }
-
     public Status getStatus(int level) {
         level -= 1;
-        Status status = this.getBaseStatus();
+        Status status = this.baseStatus;
         switch (this) {//装備名で上げ幅を決定
             case WOOD_SWORD, WOOD_SPEAR, WOOD_ARROW, WOOD_DAGGER -> {
                 status.setHP(status.getHP() + level);

--- a/src/main/java/model/Material.java
+++ b/src/main/java/model/Material.java
@@ -22,6 +22,8 @@ public enum Material {
             + "鉄ほどの強度はないが、その分扱いやすい<br>" +
             "そのために、銅の鎧は駆け出しの狩人に適する");
 
+    public static final int LENGTH = Material.values().length;
+
     private final String name;
     public final String imgPath;
     public final String txt;

--- a/src/main/java/view/Warehouse.java
+++ b/src/main/java/view/Warehouse.java
@@ -13,65 +13,75 @@ import model.Blueprint;
 public class Warehouse extends JFrame implements ActionListener {
 
     private User user;
-    /*アイテムの種類数を規定する変数*/
-    int itemVar = 5,equipVar = 23;
     private final WindowBase base;
-    private JLayeredPane menuPanel = new JLayeredPane();
-    private JLayeredPane itemInfoPane = new JLayeredPane();
-    private JLayeredPane listPane = new JLayeredPane();
-    private ImageIcon iconBackground = new ImageIcon("./assets/imgs/ログイン画面.png");    //画像のディレクトリは調整してもろて
-    private ImageIcon iconList = new ImageIcon("./assets/imgs/TestItemList.png");
-    private ImageIcon iconItemInfo = new ImageIcon("./assets/imgs/TestItemInfo.png");
-    private ImageIcon iconInfoSlot = new ImageIcon("./assets/imgs/TestEquipSlot2.png");
-    private ImageIcon iconSlot = new ImageIcon("./assets/imgs/TestEquipSlot4.png");
-    private ImageIcon iconItem = new ImageIcon("./assets/imgs/TestItemShield.png");
+    private final JLayeredPane menuPanel = new JLayeredPane();
+    private final JLayeredPane itemInfoPane = new JLayeredPane();
+    private final JLayeredPane listPane = new JLayeredPane();
+    private final ImageIcon iconBackground = new ImageIcon("./assets/imgs/ログイン画面.png");    //画像のディレクトリは調整してもろて
+    private final ImageIcon iconList = new ImageIcon("./assets/imgs/TestItemList.png");
+    private final ImageIcon iconItemInfo = new ImageIcon("./assets/imgs/TestItemInfo.png");
+    private final ImageIcon iconInfoSlot = new ImageIcon("./assets/imgs/TestEquipSlot2.png");
+    private final ImageIcon iconSlot = new ImageIcon("./assets/imgs/TestEquipSlot4.png");
+    private final ImageIcon iconItem = new ImageIcon("./assets/imgs/TestItemShield.png");
 
-    //ImageIcon icon2 = new ImageIcon("./assets/imgs/エルフ.jpg");
     ImageScaling isc = new ImageScaling();
 
     JLabel label1 = new JLabel(iconBackground);        //画像はlabelで取り込む
     JLabel itemInfoLabel = new JLabel(iconItemInfo);
     JLabel infoSlotLabel = new JLabel(iconInfoSlot);
-    JLabel[] textLabel = new JLabel[6];
+    JLabel[] textLabels = new JLabel[6];
 
     JScrollPane scrollPane = new JScrollPane();
     // viewportにscrollPaneの中のコンテンツを格納
     // scrollPane>viewport>listPane>itemButton
     JViewport viewport = scrollPane.getViewport();
-    JButton[] buttonSelector = new JButton[3];    //表示する対象を切り替えるボタン
+
+    MenuButton[] menuButtons = new MenuButton[3];    //表示する対象を切り替えるボタン
     /*各アイテムの種類ごとのボタン*/
-    itemCompoundButton[] itemButton = new itemCompoundButton[itemVar];
-    blueprintCompoundButton[] bpButton = new blueprintCompoundButton[equipVar];
+    BlueprintCompoundButton[] bpButtons = new BlueprintCompoundButton[EquipmentItem.LENGTH];
+    MaterialCompoundButton[] materialButtons = new MaterialCompoundButton[Material.LENGTH];
 
-    private class blueprintCompoundButton {   //原型が紐づけられたボタンの構造体
-        Blueprint blueprint;
-        JButton button;
+
+    private class MenuButton extends JButton {    //表示する対象を切り替えるボタンの構造体
+        MenuState state;
+
+        MenuButton(String label, MenuState state) {
+            super(label);
+            this.state = state;
+        }
     }
 
-    private class itemCompoundButton {    //アイテム情報が紐づけられたボタンの構造体
-        Material material;
-        JButton button;
+    private static class BlueprintCompoundButton extends JButton {   //原型が紐づけられたボタンの構造体
+        final Blueprint blueprint;
+
+        BlueprintCompoundButton(Icon icon, Blueprint blueprint) {
+            super(icon);
+            this.blueprint = blueprint;
+        }
     }
 
+    private static class MaterialCompoundButton extends JButton {    //アイテム情報が紐づけられたボタンの構造体
+        final Material material;
+
+        MaterialCompoundButton(Icon icon, Material material) {
+            super(icon);
+            this.material = material;
+        }
+    }
+
+    private enum MenuState {
+        EQUIPMENT, BLUEPRINT, MATERIAL
+    }
 
     public Warehouse(WindowBase base, User user) {
-
         this.base = base;
         this.user = user;
         label1.setBounds(0, 0, 816, 512);//背景の描画とレイヤーの設定
         menuPanel.add(label1);
         menuPanel.setLayer(label1, -10);
 
-        /*構造体配列の初期化*/
-        for (int i1 = 0; i1 < itemVar; i1++) {
-            itemButton[i1] = new itemCompoundButton();
-        }
-        for(int i2=0;i2<equipVar;i2++){
-            bpButton[i2] = new blueprintCompoundButton();
-        }
-
-        for (int i = 0; i < textLabel.length; i++) {
-            textLabel[i] = new JLabel();
+        for (int i = 0; i < textLabels.length; i++) {
+            textLabels[i] = new JLabel();
         }
 
         start();
@@ -84,14 +94,14 @@ public class Warehouse extends JFrame implements ActionListener {
         menuPanel.setLayout(null);      //ボタン配置の設定
 
         /*表示する対象を選択するボタンの召喚*/
-        buttonSelector[0] = new JButton("装備");
-        buttonSelector[1] = new JButton("原型");
-        buttonSelector[2] = new JButton("素材");
-        for (int i = 0; i < buttonSelector.length; i++) {
-            buttonSelector[i].setBounds(16 + i * 177, 64, 160, 32);
-            buttonSelector[i].addActionListener(this);
-            menuPanel.add(buttonSelector[i]);
-            menuPanel.setLayer(buttonSelector[i], 0);
+        menuButtons[0] = new MenuButton("装備", MenuState.EQUIPMENT);
+        menuButtons[1] = new MenuButton("原型", MenuState.BLUEPRINT);
+        menuButtons[2] = new MenuButton("素材", MenuState.MATERIAL);
+        for (int i = 0; i < menuButtons.length; i++) {
+            menuButtons[i].setBounds(16 + i * 177, 64, 160, 32);
+            menuButtons[i].addActionListener(this);
+            menuPanel.add(menuButtons[i]);
+            menuPanel.setLayer(menuButtons[i], 0);
         }
 
         /*アイテム情報表示欄の召喚*/
@@ -103,17 +113,38 @@ public class Warehouse extends JFrame implements ActionListener {
         menuPanel.setLayer(infoSlotLabel, 0);
     }
 
+    //ボタンの状態の切り替え
+    private void switchMenu(MenuState state) {
+        listPane.removeAll();
+        switch (state) {
+            case EQUIPMENT -> {
+                menuButtons[0].setEnabled(false);
+                menuButtons[1].setEnabled(true);
+                menuButtons[2].setEnabled(true);
+                showEquipmentList();
+            }
+            case BLUEPRINT -> {
+                menuButtons[0].setEnabled(true);
+                menuButtons[1].setEnabled(false);
+                menuButtons[2].setEnabled(true);
+                showBlueprintList();
+            }
+            case MATERIAL -> {
+                menuButtons[0].setEnabled(true);
+                menuButtons[1].setEnabled(true);
+                menuButtons[2].setEnabled(false);
+                showMaterialList();
+            }
+        }
+    }
+
     public void start() {    //始めに画面を呼び出したときに表示する内容の召喚
         menu();
 
-        getEquipmentList();
+        showEquipmentList();
     }
 
-    public void getEquipmentList() {   //装備一覧の取得と表示
-        listPane.removeAll();
-        buttonSelector[0].setEnabled(false);   //ボタンの状態の切り替え
-        buttonSelector[1].setEnabled(true);
-        buttonSelector[2].setEnabled(true);
+    public void showEquipmentList() {   //装備一覧の取得と表示
         int limit = 43, pf = 366;
         for (int i = 0; i < limit; i++) {
             JLabel itemSlot = new JLabel(iconSlot);
@@ -143,67 +174,41 @@ public class Warehouse extends JFrame implements ActionListener {
         menuPanel.setLayer(scrollPane, 10);
     }
 
-    public void getEquipBaseList() {
-        listPane.removeAll();
-        buttonSelector[0].setEnabled(true);
-        buttonSelector[1].setEnabled(false);
-        buttonSelector[2].setEnabled(true);
+    public void showBlueprintList() {
         int pf = 366;
 
         /*原型情報の格納*/
-        int[] bpNum = new int[equipVar];
-        ImageIcon[] bpIcon = new ImageIcon[equipVar];
-        Blueprint[] bp = new Blueprint[equipVar];
-        bp[0] = new Blueprint(EquipmentItem.LEATHER_HELMET);
-        bp[1] = new Blueprint(EquipmentItem.COPPER_HELMET);
-        bp[2] = new Blueprint(EquipmentItem.IRON_HELMET);
-        bp[3] = new Blueprint(EquipmentItem.DIAMOND_HELMET);
-        bp[4] = new Blueprint(EquipmentItem.LEATHER_ARMOR);
-        bp[5] = new Blueprint(EquipmentItem.COPPER_ARMOR);
-        bp[6] = new Blueprint(EquipmentItem.IRON_ARMOR);
-        bp[7] = new Blueprint(EquipmentItem.DIAMOND_ARMOR);
-        bp[8] = new Blueprint(EquipmentItem.WOOD_SWORD);
-        bp[9] = new Blueprint(EquipmentItem.IRON_SWORD);
-        bp[10] = new Blueprint(EquipmentItem.DIAMOND_SWORD);
-        bp[11] = new Blueprint(EquipmentItem.WOOD_SPEAR);
-        bp[12] = new Blueprint(EquipmentItem.IRON_SPEAR);
-        bp[13] = new Blueprint(EquipmentItem.DIAMOND_SPEAR);
-        bp[14] = new Blueprint(EquipmentItem.WOOD_ARROW);
-        bp[15] = new Blueprint(EquipmentItem.IRON_ARROW);
-        bp[16] = new Blueprint(EquipmentItem.DIAMOND_ARROW);
-        bp[17] = new Blueprint(EquipmentItem.WOOD_SHIELD);
-        bp[18] = new Blueprint(EquipmentItem.IRON_SHIELD);
-        bp[19] = new Blueprint(EquipmentItem.DIAMOND_SHIELD);
-        bp[20] = new Blueprint(EquipmentItem.WOOD_DAGGER);
-        bp[21] = new Blueprint(EquipmentItem.IRON_DAGGER);
-        bp[22] = new Blueprint(EquipmentItem.DIAMOND_DAGGER);
+        ImageIcon[] bpIcon = new ImageIcon[EquipmentItem.LENGTH];
+        EquipmentItem[] eItems = EquipmentItem.values();
 
-        for (int i = 0; i < equipVar; i++) {
+        for (int i = 0; i < eItems.length; i++) {
+            EquipmentItem targetItem = eItems[i];
             /*背景の枠の表示*/
             JLabel itemSlot = new JLabel(iconSlot);
             itemSlot.setBounds(16 + 80 * (i % 6), 16 + 80 * (i / 6), 64, 64);
             listPane.add(itemSlot);
             listPane.setLayer(itemSlot, 0);
             /*blueprintCompoundButtonを用いたボタン表示*/
-            bpButton[i].blueprint = bp[i];
-            bpIcon[i] = new ImageIcon(bp[i].baseItem().getAssetPath());
-            bpButton[i].button = new JButton(isc.scale(bpIcon[i], 2.0));
-            bpButton[i].button.setBorderPainted(false);
-            bpButton[i].button.setContentAreaFilled(false);
-            bpButton[i].button.setBounds(16 + 80 * (i % 6), 16 + 80 * (i / 6), 64, 64);
-            listPane.add(bpButton[i].button);
-            bpButton[i].button.addActionListener(this);
-            listPane.setLayer(bpButton[i].button, 10);
+            bpIcon[i] = new ImageIcon(targetItem.getAssetPath());
+            BlueprintCompoundButton newButton = new BlueprintCompoundButton(isc.scale(bpIcon[i], 2.0), new Blueprint(targetItem));
+            newButton.setBorderPainted(false);
+            newButton.setContentAreaFilled(false);
+            newButton.setBounds(16 + 80 * (i % 6), 16 + 80 * (i / 6), 64, 64);
+            newButton.addActionListener(this);
+            listPane.add(newButton);
+            listPane.setLayer(newButton, 10);
+            bpButtons[i] = newButton;
+
             /*アイテム数の表示*/
-            bpNum[i] = user.getBlueprintQuantity(bp[i]);
-            JLabel num = new JLabel(String.valueOf(bpNum[i]));
-            num.setBounds(64 + 80 * (i % 6), 64 + 80 * (i / 6), 32, 32);
-            num.setFont(new Font("ＭＳ ゴシック", Font.PLAIN, 20));
-            listPane.add(num);
-            listPane.setLayer(num, 20);
+            String bqQuantity = String.valueOf(user.getBlueprintQuantity(new Blueprint(targetItem)));
+            JLabel numLabel = new JLabel(bqQuantity);
+            numLabel.setBounds(64 + 80 * (i % 6), 64 + 80 * (i / 6), 32, 32);
+            numLabel.setFont(new Font("ＭＳ ゴシック", Font.PLAIN, 20));
+            listPane.add(numLabel);
+            listPane.setLayer(numLabel, 20);
         }
         /*背景の表示*/
-        int n = ((int) Math.ceil((double) equipVar / 6.0)) * 80 + 16;
+        int n = ((int) Math.ceil((double) EquipmentItem.LENGTH / 6.0)) * 80 + 16;
         if (n > 366) pf = n;
         for (int i = 0; i * 80 - 64 <= pf; i++) {
             JLabel listLabel = new JLabel(iconList);
@@ -220,49 +225,40 @@ public class Warehouse extends JFrame implements ActionListener {
         menuPanel.setLayer(scrollPane, 10);
     }
 
-    public void getItemList() {         //素材アイテムをリストとして表示する
-        listPane.removeAll();
-        buttonSelector[0].setEnabled(true);  //押せるボタンの切り替え
-        buttonSelector[1].setEnabled(true);
-        buttonSelector[2].setEnabled(false);
+    public void showMaterialList() {         //素材アイテムをリストとして表示する
         int pf = 366;             //アイテムの数とスクロールの最大値
 
         /*各アイテムの数量とアイコンを取得する下準備*/
-        int[] itemNum = new int[itemVar];
-        ImageIcon[] itemIcon = new ImageIcon[itemVar];
-        Material[] material = new Material[itemVar];
-        material[0] = Material.WOOD;
-        material[1] = Material.IRON;
-        material[2] = Material.DIAMOND;
-        material[3] = Material.LEATHER;
-        material[4] = Material.BRONZE;
-
-        for (int i = 0; i < itemVar; i++) {
+        Material[] materials = Material.values();
+        for (int i = 0; i < materials.length; i++) {
             /*背景の枠の表示*/
             JLabel itemSlot = new JLabel(iconSlot);
             itemSlot.setBounds(16 + 80 * (i % 6), 16 + 80 * (i / 6), 64, 64);
             listPane.add(itemSlot);
             listPane.setLayer(itemSlot, 0);
-            /*itemCompoundButtonを用いたアイテム用ボタンの表示*/
-            itemIcon[i] = new ImageIcon(material[i].getAssetPath());
-            itemButton[i].material = material[i];
-            itemButton[i].button = new JButton(isc.scale(itemIcon[i], 2.0));
-            itemButton[i].button.setBorderPainted(false);
-            itemButton[i].button.setContentAreaFilled(false);
-            itemButton[i].button.setBounds(16 + 80 * (i % 6), 16 + 80 * (i / 6), 64, 64);
-            listPane.add(itemButton[i].button);
-            itemButton[i].button.addActionListener(this);
-            listPane.setLayer(itemButton[i].button, 10);
+
+            /*MaterialCompoundButtonを用いたアイテム用ボタンの表示*/
+            ImageIcon materialIcon = new ImageIcon(materials[i].getAssetPath());
+            MaterialCompoundButton newButton = new MaterialCompoundButton(isc.scale(materialIcon, 2.0), materials[i]);
+            newButton.setBorderPainted(false);
+            newButton.setContentAreaFilled(false);
+            newButton.setBounds(16 + 80 * (i % 6), 16 + 80 * (i / 6), 64, 64);
+            newButton.addActionListener(this);
+            listPane.add(newButton);
+            listPane.setLayer(newButton, 10);
+            materialButtons[i] = newButton;
+
             /*アイテムの数の表示*/
-            itemNum[i] = user.getMaterialQuantity(material[i]);
-            JLabel num = new JLabel(String.valueOf(itemNum[i]));
-            num.setBounds(64 + 80 * (i % 6), 64 + 80 * (i / 6), 32, 32);
-            num.setFont(new Font("ＭＳ ゴシック", Font.PLAIN, 20));
-            listPane.add(num);
-            listPane.setLayer(num, 20);
+            String itemQuantity = String.valueOf(user.getMaterialQuantity(materials[i]));
+            JLabel numLabel = new JLabel(itemQuantity);
+
+            numLabel.setBounds(64 + 80 * (i % 6), 64 + 80 * (i / 6), 32, 32);
+            numLabel.setFont(new Font("ＭＳ ゴシック", Font.PLAIN, 20));
+            listPane.add(numLabel);
+            listPane.setLayer(numLabel, 20);
         }
         /*背景の表示*/
-        int n = ((int) Math.ceil((double) itemVar / 6.0)) * 80 + 16;
+        int n = ((int) Math.ceil((double) model.Material.LENGTH / 6.0)) * 80 + 16;
         if (n > 366) pf = n;
         for (int i = 0; i * 80 - 64 <= pf; i++) {
             JLabel listLabel = new JLabel(iconList);
@@ -279,11 +275,11 @@ public class Warehouse extends JFrame implements ActionListener {
         menuPanel.setLayer(scrollPane, 10);
     }
 
-    public void putBpInfo(int n){       //原型の情報を表示するメソッド
+    public void putBpInfo(Blueprint bp) {       //原型の情報を表示するメソッド
         itemInfoPane.removeAll();
 
         /*アイテム名の表示*/
-        JLabel bpName = new JLabel(bpButton[n].blueprint.baseItem().name);
+        JLabel bpName = new JLabel(bp.baseItem().name);
         bpName.setBounds(0, 0, 256, 32);
         bpName.setHorizontalAlignment(JLabel.CENTER);
         bpName.setFont(new Font("ＭＳ ゴシック", Font.BOLD, 24));
@@ -291,13 +287,13 @@ public class Warehouse extends JFrame implements ActionListener {
         itemInfoPane.setLayer(bpName, 0);
 
         /*アイコン表示*/
-        JLabel bpIcon = new JLabel(isc.scale(new ImageIcon(bpButton[n].blueprint.baseItem().getAssetPath()), 4.0));
+        JLabel bpIcon = new JLabel(isc.scale(new ImageIcon(bp.baseItem().getAssetPath()), 4.0));
         bpIcon.setBounds(64, 32, 128, 128);
         itemInfoPane.add(bpIcon);
         itemInfoPane.setLayer(bpIcon, 0);
 
         /*アイテムの所持数の表示*/
-        JLabel bpNum = new JLabel("所持数：" + user.getBlueprintQuantity(bpButton[n].blueprint));
+        JLabel bpNum = new JLabel("所持数：" + user.getBlueprintQuantity(bp));
         bpNum.setBounds(0, 160, 256, 32);
         bpNum.setHorizontalAlignment(JLabel.CENTER);
         bpNum.setFont(new Font("ＭＳ ゴシック", Font.PLAIN, 20));
@@ -305,7 +301,7 @@ public class Warehouse extends JFrame implements ActionListener {
         itemInfoPane.setLayer(bpNum, 0);
 
         /*説明文の表示*/
-        String txt = "<html>" + bpButton[n].blueprint.baseItem().name +
+        String txt = "<html>" + bp.baseItem().name +
                 "の設計図<br>" + "このままでは装備できない<br><br>"
                 + "素材を集めることで、装備を製造することができる<br>"
                 + "装備を製造すると、設計図は消費される";
@@ -321,11 +317,11 @@ public class Warehouse extends JFrame implements ActionListener {
         menuPanel.setLayer(itemInfoPane, 10);
     }
 
-    public void putItemInfo(int n){       //素材アイテムの情報を表示するメソッド
+    public void putItemInfo(Material material) {       //素材アイテムの情報を表示するメソッド
         itemInfoPane.removeAll();
 
         /*アイテム名の表示*/
-        JLabel itemName = new JLabel(itemButton[n].material.getName());
+        JLabel itemName = new JLabel(material.getName());
         itemName.setBounds(0, 0, 256, 32);
         itemName.setHorizontalAlignment(JLabel.CENTER);
         itemName.setFont(new Font("ＭＳ ゴシック", Font.BOLD, 24));
@@ -333,13 +329,13 @@ public class Warehouse extends JFrame implements ActionListener {
         itemInfoPane.setLayer(itemName, 0);
 
         /*アイコン表示*/
-        JLabel itemIcon = new JLabel(isc.scale(new ImageIcon(itemButton[n].material.getAssetPath()), 4.0));
+        JLabel itemIcon = new JLabel(isc.scale(new ImageIcon(material.getAssetPath()), 4.0));
         itemIcon.setBounds(64, 32, 128, 128);
         itemInfoPane.add(itemIcon);
         itemInfoPane.setLayer(itemIcon, 0);
 
         /*アイテムの所持数の表示*/
-        JLabel itemNum = new JLabel("所持数：" + user.getMaterialQuantity(itemButton[n].material));
+        JLabel itemNum = new JLabel("所持数：" + user.getMaterialQuantity(material));
         itemNum.setBounds(0, 160, 256, 32);
         itemNum.setHorizontalAlignment(JLabel.CENTER);
         itemNum.setFont(new Font("ＭＳ ゴシック", Font.PLAIN, 20));
@@ -347,7 +343,7 @@ public class Warehouse extends JFrame implements ActionListener {
         itemInfoPane.setLayer(itemNum, 0);
 
         /*フレーバーテキストの表示*/
-        JLabel itemTxt = new JLabel(itemButton[n].material.getTxt());
+        JLabel itemTxt = new JLabel(material.getTxt());
         itemTxt.setBounds(0, 192, 256, 256);
         itemTxt.setVerticalAlignment(JLabel.TOP);
         itemTxt.setFont(new Font("ＭＳ ゴシック", Font.PLAIN, 16));
@@ -360,30 +356,27 @@ public class Warehouse extends JFrame implements ActionListener {
     }
 
     public void actionPerformed(ActionEvent e) {
-        // Upgradeボタンが押されたときの処理
-        if (e.getSource() == buttonSelector[0]) {
-            System.out.println("装だよ(便乗)");
-            getEquipmentList();
-        }
-        if (e.getSource() == buttonSelector[1]) {
-            System.out.println("原型は製造しないと使えないぜっ！");
-            getEquipBaseList();
-        }
-        if (e.getSource() == buttonSelector[2]) {
-            System.out.println("ラストエリクサーなんてないよ");
-            getItemList();
-        }
-        for(int i=0;i<itemVar;i++){
-            if(e.getSource() == itemButton[i].button){
-                putItemInfo(i);
-            }
-        }
-        for(int i=0;i<equipVar;i++){
-            if(e.getSource() == bpButton[i].button){
-                putBpInfo(i);
-            }
+        Object source = e.getSource();
+
+        // MenuButtonが押されたときの処理(切り替えボタン)
+        if (source instanceof MenuButton) {
+            switchMenu(((MenuButton) source).state);
+            return;
         }
 
+        // BlueprintListのボタンが押されたときの処理
+        if (source instanceof BlueprintCompoundButton) {
+            putBpInfo(((BlueprintCompoundButton) source).blueprint);
+            return;
+        }
+
+        // MaterialListのボタンが押されたときの処理
+        if (source instanceof MaterialCompoundButton) {
+            putItemInfo(((MaterialCompoundButton) source).material);
+            return;
+        }
+
+        // TODO: Upgradeボタンが押されたときの処理
     }
 
     public static void main(String args[]) {

--- a/src/main/java/view/Warehouse.java
+++ b/src/main/java/view/Warehouse.java
@@ -11,6 +11,7 @@ import model.util.User;
 public class Warehouse extends JFrame implements ActionListener {
 
     private User user;
+    /*アイテムの種類数を規定する変数*/
     int itemVar = 5;
     private final WindowBase base;
     private JLayeredPane menuPanel = new JLayeredPane();
@@ -35,7 +36,8 @@ public class Warehouse extends JFrame implements ActionListener {
     // viewportにscrollPaneの中のコンテンツを格納
     // scrollPane>viewport>listPane>itemButton
     JViewport viewport = scrollPane.getViewport();
-    JButton[] buttonSelector = new JButton[3];
+    JButton[] buttonSelector = new JButton[3];    //表示する対象を切り替えるボタン
+    /*各アイテムの種類ごとのボタン*/
     itemCompoundButton[] itemButton = new itemCompoundButton[itemVar];
 
     private class itemCompoundButton {    //アイテム情報が紐づけられたボタンの構造体
@@ -70,6 +72,7 @@ public class Warehouse extends JFrame implements ActionListener {
 
         menuPanel.setLayout(null);      //ボタン配置の設定
 
+        /*表示する対象を選択するボタンの召喚*/
         buttonSelector[0] = new JButton("装備");
         buttonSelector[1] = new JButton("原型");
         buttonSelector[2] = new JButton("素材");
@@ -80,6 +83,7 @@ public class Warehouse extends JFrame implements ActionListener {
             menuPanel.setLayer(buttonSelector[i], 0);
         }
 
+        /*アイテム情報表示欄の召喚*/
         itemInfoLabel.setBounds(546, 32, 256, 464);
         menuPanel.add(itemInfoLabel);
         menuPanel.setLayer(itemInfoLabel, -5);
@@ -88,15 +92,15 @@ public class Warehouse extends JFrame implements ActionListener {
         menuPanel.setLayer(infoSlotLabel, 0);
     }
 
-    public void start() {
+    public void start() {    //始めに画面を呼び出したときに表示する内容の召喚
         menu();
 
         getEquipmentList();
     }
 
-    public void getEquipmentList() {
+    public void getEquipmentList() {   //装備一覧の取得と表示
         listPane.removeAll();
-        buttonSelector[0].setEnabled(false);
+        buttonSelector[0].setEnabled(false);   //ボタンの状態の切り替え
         buttonSelector[1].setEnabled(true);
         buttonSelector[2].setEnabled(true);
         int limit = 43, pf = 366;
@@ -203,6 +207,7 @@ public class Warehouse extends JFrame implements ActionListener {
             listPane.add(num);
             listPane.setLayer(num, 20);
         }
+        /*アイテム数の表示*/
         int n = ((int) Math.ceil((double) itemVar / 6.0)) * 80 + 16;
         if (n > 366) pf = n;
         for (int i = 0; i * 80 - 64 <= pf; i++) {
@@ -211,6 +216,7 @@ public class Warehouse extends JFrame implements ActionListener {
             listPane.add(listLabel);
             listPane.setLayer(listLabel, -10);
         }
+        /*リストを画面本体に配置する*/
         listPane.setBounds(0, 0, 496, 10000);
         listPane.setPreferredSize(new Dimension(496, pf));
         viewport.setView(listPane);

--- a/src/main/java/view/Warehouse.java
+++ b/src/main/java/view/Warehouse.java
@@ -5,14 +5,16 @@ import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
+import model.EquipmentItem;
 import model.Material;
 import model.util.User;
+import model.Blueprint;
 
 public class Warehouse extends JFrame implements ActionListener {
 
     private User user;
     /*アイテムの種類数を規定する変数*/
-    int itemVar = 5;
+    int itemVar = 5,equipVar = 23;
     private final WindowBase base;
     private JLayeredPane menuPanel = new JLayeredPane();
     private JLayeredPane itemInfoPane = new JLayeredPane();
@@ -39,6 +41,12 @@ public class Warehouse extends JFrame implements ActionListener {
     JButton[] buttonSelector = new JButton[3];    //表示する対象を切り替えるボタン
     /*各アイテムの種類ごとのボタン*/
     itemCompoundButton[] itemButton = new itemCompoundButton[itemVar];
+    blueprintCompoundButton[] bpButton = new blueprintCompoundButton[equipVar];
+
+    private class blueprintCompoundButton {   //原型が紐づけられたボタンの構造体
+        Blueprint blueprint;
+        JButton button;
+    }
 
     private class itemCompoundButton {    //アイテム情報が紐づけられたボタンの構造体
         Material material;
@@ -57,6 +65,9 @@ public class Warehouse extends JFrame implements ActionListener {
         /*構造体配列の初期化*/
         for (int i1 = 0; i1 < itemVar; i1++) {
             itemButton[i1] = new itemCompoundButton();
+        }
+        for(int i2=0;i2<equipVar;i2++){
+            bpButton[i2] = new blueprintCompoundButton();
         }
 
         for (int i = 0; i < textLabel.length; i++) {
@@ -137,20 +148,62 @@ public class Warehouse extends JFrame implements ActionListener {
         buttonSelector[0].setEnabled(true);
         buttonSelector[1].setEnabled(false);
         buttonSelector[2].setEnabled(true);
-        int limit = 28, pf = 366;
-        for (int i = 0; i < limit; i++) {
+        int pf = 366;
+
+        /*原型情報の格納*/
+        int[] bpNum = new int[equipVar];
+        ImageIcon[] bpIcon = new ImageIcon[equipVar];
+        Blueprint[] bp = new Blueprint[equipVar];
+        bp[0] = new Blueprint(EquipmentItem.LEATHER_HELMET);
+        bp[1] = new Blueprint(EquipmentItem.COPPER_HELMET);
+        bp[2] = new Blueprint(EquipmentItem.IRON_HELMET);
+        bp[3] = new Blueprint(EquipmentItem.DIAMOND_HELMET);
+        bp[4] = new Blueprint(EquipmentItem.LEATHER_ARMOR);
+        bp[5] = new Blueprint(EquipmentItem.COPPER_ARMOR);
+        bp[6] = new Blueprint(EquipmentItem.IRON_ARMOR);
+        bp[7] = new Blueprint(EquipmentItem.DIAMOND_ARMOR);
+        bp[8] = new Blueprint(EquipmentItem.WOOD_SWORD);
+        bp[9] = new Blueprint(EquipmentItem.IRON_SWORD);
+        bp[10] = new Blueprint(EquipmentItem.DIAMOND_SWORD);
+        bp[11] = new Blueprint(EquipmentItem.WOOD_SPEAR);
+        bp[12] = new Blueprint(EquipmentItem.IRON_SPEAR);
+        bp[13] = new Blueprint(EquipmentItem.DIAMOND_SPEAR);
+        bp[14] = new Blueprint(EquipmentItem.WOOD_ARROW);
+        bp[15] = new Blueprint(EquipmentItem.IRON_ARROW);
+        bp[16] = new Blueprint(EquipmentItem.DIAMOND_ARROW);
+        bp[17] = new Blueprint(EquipmentItem.WOOD_SHIELD);
+        bp[18] = new Blueprint(EquipmentItem.IRON_SHIELD);
+        bp[19] = new Blueprint(EquipmentItem.DIAMOND_SHIELD);
+        bp[20] = new Blueprint(EquipmentItem.WOOD_DAGGER);
+        bp[21] = new Blueprint(EquipmentItem.IRON_DAGGER);
+        bp[22] = new Blueprint(EquipmentItem.DIAMOND_DAGGER);
+
+        for (int i = 0; i < equipVar; i++) {
+            /*背景の枠の表示*/
             JLabel itemSlot = new JLabel(iconSlot);
             itemSlot.setBounds(16 + 80 * (i % 6), 16 + 80 * (i / 6), 64, 64);
             listPane.add(itemSlot);
             listPane.setLayer(itemSlot, 0);
-            JButton itemButton = new JButton(isc.scale(iconItem, 2.0));
-            itemButton.setBorderPainted(false);
-            itemButton.setContentAreaFilled(false);
-            itemButton.setBounds(16 + 80 * (i % 6), 16 + 80 * (i / 6), 64, 64);
-            listPane.add(itemButton);
-            listPane.setLayer(itemButton, 10);
+            /*blueprintCompoundButtonを用いたボタン表示*/
+            bpButton[i].blueprint = bp[i];
+            bpIcon[i] = new ImageIcon(bp[i].baseItem().getAssetPath());
+            bpButton[i].button = new JButton(isc.scale(bpIcon[i], 2.0));
+            bpButton[i].button.setBorderPainted(false);
+            bpButton[i].button.setContentAreaFilled(false);
+            bpButton[i].button.setBounds(16 + 80 * (i % 6), 16 + 80 * (i / 6), 64, 64);
+            listPane.add(bpButton[i].button);
+            bpButton[i].button.addActionListener(this);
+            listPane.setLayer(bpButton[i].button, 10);
+            /*アイテム数の表示*/
+            bpNum[i] = user.getBlueprintQuantity(bp[i]);
+            JLabel num = new JLabel(String.valueOf(bpNum[i]));
+            num.setBounds(64 + 80 * (i % 6), 64 + 80 * (i / 6), 32, 32);
+            num.setFont(new Font("ＭＳ ゴシック", Font.PLAIN, 20));
+            listPane.add(num);
+            listPane.setLayer(num, 20);
         }
-        int n = ((int) Math.ceil((double) limit / 6.0)) * 80 + 16;
+        /*背景の表示*/
+        int n = ((int) Math.ceil((double) equipVar / 6.0)) * 80 + 16;
         if (n > 366) pf = n;
         for (int i = 0; i * 80 - 64 <= pf; i++) {
             JLabel listLabel = new JLabel(iconList);
@@ -158,6 +211,7 @@ public class Warehouse extends JFrame implements ActionListener {
             listPane.add(listLabel);
             listPane.setLayer(listLabel, -10);
         }
+        /*リストを本体に配置*/
         listPane.setBounds(0, 0, 496, 10000);
         listPane.setPreferredSize(new Dimension(496, pf));
         viewport.setView(listPane);
@@ -192,7 +246,7 @@ public class Warehouse extends JFrame implements ActionListener {
             /*itemCompoundButtonを用いたアイテム用ボタンの表示*/
             itemIcon[i] = new ImageIcon(material[i].getAssetPath());
             itemButton[i].material = material[i];
-            itemButton[i].button = new JButton(isc.scale(new ImageIcon(material[i].getAssetPath()), 2.0));
+            itemButton[i].button = new JButton(isc.scale(itemIcon[i], 2.0));
             itemButton[i].button.setBorderPainted(false);
             itemButton[i].button.setContentAreaFilled(false);
             itemButton[i].button.setBounds(16 + 80 * (i % 6), 16 + 80 * (i / 6), 64, 64);
@@ -207,7 +261,7 @@ public class Warehouse extends JFrame implements ActionListener {
             listPane.add(num);
             listPane.setLayer(num, 20);
         }
-        /*アイテム数の表示*/
+        /*背景の表示*/
         int n = ((int) Math.ceil((double) itemVar / 6.0)) * 80 + 16;
         if (n > 366) pf = n;
         for (int i = 0; i * 80 - 64 <= pf; i++) {
@@ -223,6 +277,48 @@ public class Warehouse extends JFrame implements ActionListener {
         scrollPane.setBounds(16, 112, 496 + 18, 366 + 18);
         menuPanel.add(scrollPane);
         menuPanel.setLayer(scrollPane, 10);
+    }
+
+    public void putBpInfo(int n){       //原型の情報を表示するメソッド
+        itemInfoPane.removeAll();
+
+        /*アイテム名の表示*/
+        JLabel bpName = new JLabel(bpButton[n].blueprint.baseItem().name);
+        bpName.setBounds(0, 0, 256, 32);
+        bpName.setHorizontalAlignment(JLabel.CENTER);
+        bpName.setFont(new Font("ＭＳ ゴシック", Font.BOLD, 24));
+        itemInfoPane.add(bpName);
+        itemInfoPane.setLayer(bpName, 0);
+
+        /*アイコン表示*/
+        JLabel bpIcon = new JLabel(isc.scale(new ImageIcon(bpButton[n].blueprint.baseItem().getAssetPath()), 4.0));
+        bpIcon.setBounds(64, 32, 128, 128);
+        itemInfoPane.add(bpIcon);
+        itemInfoPane.setLayer(bpIcon, 0);
+
+        /*アイテムの所持数の表示*/
+        JLabel bpNum = new JLabel("所持数：" + user.getBlueprintQuantity(bpButton[n].blueprint));
+        bpNum.setBounds(0, 160, 256, 32);
+        bpNum.setHorizontalAlignment(JLabel.CENTER);
+        bpNum.setFont(new Font("ＭＳ ゴシック", Font.PLAIN, 20));
+        itemInfoPane.add(bpNum);
+        itemInfoPane.setLayer(bpNum, 0);
+
+        /*説明文の表示*/
+        String txt = "<html>" + bpButton[n].blueprint.baseItem().name +
+                "の設計図<br>" + "このままでは装備できない<br><br>"
+                + "素材を集めることで、装備を製造することができる<br>"
+                + "装備を製造すると、設計図は消費される";
+        JLabel bpTxt = new JLabel(txt);
+        bpTxt.setBounds(0, 192, 256, 256);
+        bpTxt.setVerticalAlignment(JLabel.TOP);
+        bpTxt.setFont(new Font("ＭＳ ゴシック", Font.PLAIN, 16));
+        itemInfoPane.add(bpTxt);
+        itemInfoPane.setLayer(bpTxt, 0);
+
+        itemInfoPane.setBounds(546, 32, 256, 464);
+        menuPanel.add(itemInfoPane);
+        menuPanel.setLayer(itemInfoPane, 10);
     }
 
     public void putItemInfo(int n){       //素材アイテムの情報を表示するメソッド
@@ -280,6 +376,11 @@ public class Warehouse extends JFrame implements ActionListener {
         for(int i=0;i<itemVar;i++){
             if(e.getSource() == itemButton[i].button){
                 putItemInfo(i);
+            }
+        }
+        for(int i=0;i<equipVar;i++){
+            if(e.getSource() == bpButton[i].button){
+                putBpInfo(i);
             }
         }
 


### PR DESCRIPTION
| Property            | Value |
|:--------------------|:------|
| Corresponding Issue | #     |
| Assignee            | @     |

# PRで実装される機能
製造画面とアイテム一覧での所持している設計図の一覧表示
アイコンを押すと詳細情報を表示する

製造画面の方では持っていない設計図は表示されない

# PRで修正される機能
変数の使い方なんかのマイナーチェンジ
たぶん気にしなくていい

# レビューをお願いしたいポイント
動くかどうか
設計図用背景の画像は完成次第適用するんで言ってちょんまげ

